### PR TITLE
Patching deployment

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -55,7 +55,7 @@
         "mocha": "^10.2.0",
         "sinon": "^15.2.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev-start": "nodemon --exec ts-node src/server.ts",
     "build": "tsc && npm run copy-sql",
     "gcp-build": "npm install --save-dev && npm run build",
-    "copy-sql": "cp ./src/db/db_init.sql ./dist/src/db/db_init.sql",
+    "copy-sql": "cp ./src/db/db_init.sql ./dist/db/db_init.sql",
     "tsconfig": "tsc --init",
     "test": "mocha"
   },
@@ -62,6 +62,6 @@
     "mocha": "^10.2.0",
     "sinon": "^15.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,8 +7,6 @@
     "esModuleInterop": true
   },
   "include": [
-    "src", 
-    "src/db/db_init.sql",
-    "test"
+    "src"
   ]
 }


### PR DESCRIPTION
Before adding tests, build would "compile" all files rom src/ directly into /dist, but with tests, it started splitting it into /dist/src and /dist/test, which broke the deployment workflow.

Patching it so that only /src files are "compiled" during production build